### PR TITLE
docs: fix simple typo, higest -> highest

### DIFF
--- a/algorithms/list.py
+++ b/algorithms/list.py
@@ -24,7 +24,7 @@ def find_int(i, lst):
 
 
 def find_max_sub(lst):
-    """Find subset with higest sum.
+    """Find subset with highest sum.
 
     Example: [-2, 3, -4, 5, 1, -5] -> (3,4), 6
     @param lst list


### PR DESCRIPTION
There is a small typo in algorithms/list.py.

Should read `highest` rather than `higest`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md